### PR TITLE
Add new unique FHSRIDs to BigQuery with first seen date

### DIFF
--- a/DUPLICATE_PREVENTION_GUIDE.md
+++ b/DUPLICATE_PREVENTION_GUIDE.md
@@ -1,0 +1,143 @@
+# BigQuery Duplicate Prevention Guide
+
+## Current Implementation Status ✅
+
+**The system already implements the duplicate prevention logic you requested!** Here's how it works:
+
+### 1. Data Collection Flow
+
+```
+API Data Collection → Load Existing BigQuery Data → Compare FHRSIDs → Add Only New Records
+```
+
+### 2. Duplicate Prevention Logic (Already Implemented)
+
+#### Step 1: Load Existing Data (`data_processing.py`, lines 93-109)
+```python
+existing_fhrsid_set = set()
+for est in master_data:
+    if isinstance(est, dict):
+        # Check for both 'FHRSID' and 'fhrsid' keys
+        if 'FHRSID' in est and est['FHRSID'] is not None:
+            fhrsid_val = est['FHRSID']
+        elif 'fhrsid' in est and est['fhrsid'] is not None:
+            fhrsid_val = est['fhrsid']
+        
+        # Canonicalize and add to existing set
+        canonical_fhrsid = str(int(fhrsid_val))  # Normalize format
+        existing_fhrsid_set.add(canonical_fhrsid)
+```
+
+#### Step 2: Check Against Existing FHRSIDs (`data_processing.py`, line 127)
+```python
+if canonical_api_fhrsid not in existing_fhrsid_set:
+    # Only process if FHRSID doesn't exist in BigQuery
+```
+
+#### Step 3: Assign first_seen Date Only to New Records (`data_processing.py`, line 130)
+```python
+api_establishment['first_seen'] = today_date  # Only for new records
+api_establishment['manual_review'] = "not reviewed"
+```
+
+#### Step 4: Append Only New Records (`st_app.py`, lines 398-415)
+```python
+# process_and_update_master_data returns ONLY new restaurants
+new_restaurants = process_and_update_master_data(master_restaurant_data, combined_api_data)
+
+# Append only the new records
+_append_new_data_to_bigquery(new_restaurants, project_id, dataset_id, table_id)
+```
+
+### 3. Additional Safeguards
+
+The system also handles:
+- **Duplicate FHRSIDs within the same API batch** (lines 113, 129, 149 in `data_processing.py`)
+- **Canonical FHRSID formatting** to ensure consistent comparison (e.g., "123" vs 123)
+- **Both 'FHRSID' and 'fhrsid' field names** for compatibility
+
+## How It Works in Practice
+
+1. **First Run (Empty BigQuery table)**:
+   - API returns 100 restaurants with FHRSIDs: [1, 2, 3, ..., 100]
+   - BigQuery is empty, so `existing_fhrsid_set` = {}
+   - All 100 records are new → All get `first_seen` date → All are added to BigQuery
+
+2. **Second Run (BigQuery has 100 records)**:
+   - API returns 120 restaurants with FHRSIDs: [1, 2, 3, ..., 100, 101, 102, ..., 120]
+   - BigQuery has [1, 2, 3, ..., 100], so `existing_fhrsid_set` = {1, 2, ..., 100}
+   - Only FHRSIDs [101, 102, ..., 120] are new
+   - Only these 20 records get `first_seen` date and are added to BigQuery
+
+3. **Third Run (BigQuery has 120 records)**:
+   - API returns same 120 restaurants
+   - All FHRSIDs already exist in BigQuery
+   - No new records are added
+
+## Optional Enhancement: Database-Level Duplicate Prevention
+
+While the current implementation works correctly, you can add an extra layer of protection using BigQuery's MERGE statement instead of APPEND. This ensures duplicate prevention at the database level.
+
+### Benefits of MERGE Approach:
+- **Database-level guarantee**: Even if application logic fails, BigQuery won't insert duplicates
+- **Atomic operation**: All-or-nothing transaction
+- **Better visibility**: BigQuery reports exact number of records inserted vs skipped
+
+### How to Enable MERGE (Optional):
+
+1. **Add the new merge utilities**:
+   ```python
+   from bq_utils_merge import merge_new_restaurants_to_bigquery
+   ```
+
+2. **Replace the append call in `st_app.py`** (line 415):
+   ```python
+   # Instead of:
+   _append_new_data_to_bigquery(new_restaurants, project_id_append, dataset_id_append, table_id_append)
+   
+   # Use:
+   _append_new_data_to_bigquery_with_merge(new_restaurants, project_id_append, dataset_id_append, table_id_append)
+   ```
+
+### MERGE SQL Example:
+```sql
+MERGE `project.dataset.restaurants` AS target
+USING `project.dataset.restaurants_temp` AS source
+ON target.fhrsid = source.fhrsid
+WHEN NOT MATCHED THEN
+    INSERT (fhrsid, businessname, first_seen, ...)
+    VALUES (source.fhrsid, source.businessname, source.first_seen, ...)
+```
+
+## Testing the Duplicate Prevention
+
+To verify the system is working correctly:
+
+1. **Run initial data fetch**:
+   - Note the number of records added
+   - Check BigQuery for the records with their `first_seen` dates
+
+2. **Run the same fetch again immediately**:
+   - Should report "0 new restaurants found" or similar
+   - BigQuery table should have the same number of records
+   - No duplicate FHRSIDs should exist
+
+3. **Query to check for duplicates**:
+   ```sql
+   SELECT fhrsid, COUNT(*) as count
+   FROM `project.dataset.restaurants`
+   GROUP BY fhrsid
+   HAVING count > 1
+   ```
+   This should return no results if duplicate prevention is working.
+
+## Summary
+
+✅ **Current Status**: The application already implements complete duplicate prevention:
+- Only FHRSIDs not in BigQuery get added
+- Only new records get `first_seen` dates
+- The system uses APPEND to add only new rows
+
+🔧 **Optional Enhancement**: Use MERGE for database-level duplicate prevention (code provided in `bq_utils_merge.py` and `enhanced_st_app_section.py`)
+
+📊 **Result**: No duplicate FHRSIDs will exist in your BigQuery table, and each restaurant will have the correct `first_seen` date from when it was first discovered.

--- a/bq_utils_merge.py
+++ b/bq_utils_merge.py
@@ -1,0 +1,225 @@
+"""
+Enhanced BigQuery utilities with MERGE capability for duplicate prevention.
+This module provides an alternative approach using MERGE statements to ensure
+no duplicate FHRSIDs are inserted at the database level.
+"""
+
+import streamlit as st
+import pandas as pd
+from google.cloud import bigquery
+from typing import List, Dict, Any
+import logging
+from datetime import datetime
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+def merge_new_restaurants_to_bigquery(
+    new_restaurants_df: pd.DataFrame,
+    project_id: str,
+    dataset_id: str,
+    table_id: str,
+    bq_schema: List[bigquery.SchemaField]
+) -> bool:
+    """
+    Merges new restaurant data into BigQuery table using MERGE statement.
+    This ensures that only FHRSIDs that don't exist in the target table are inserted.
+    
+    Args:
+        new_restaurants_df: DataFrame containing new restaurant data with sanitized column names
+        project_id: The Google Cloud project ID
+        dataset_id: The BigQuery dataset ID
+        table_id: The BigQuery table ID
+        bq_schema: List of BigQuery schema fields
+        
+    Returns:
+        True if merge was successful, False otherwise
+    """
+    if new_restaurants_df.empty:
+        st.info("No new restaurants to merge into BigQuery.")
+        return True
+    
+    client = bigquery.Client(project=project_id)
+    table_ref = f"{project_id}.{dataset_id}.{table_id}"
+    temp_table_id = f"{table_id}_temp_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+    temp_table_ref = f"{project_id}.{dataset_id}.{temp_table_id}"
+    
+    try:
+        # Step 1: Create a temporary table with the new data
+        st.info(f"Creating temporary table {temp_table_id} with {len(new_restaurants_df)} new records...")
+        
+        job_config = bigquery.LoadJobConfig(
+            schema=bq_schema,
+            write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+            column_name_character_map="V2",
+        )
+        
+        job = client.load_table_from_dataframe(
+            new_restaurants_df, 
+            temp_table_ref, 
+            job_config=job_config
+        )
+        job.result()  # Wait for the job to complete
+        
+        # Step 2: Execute MERGE statement
+        # Build column list for INSERT
+        column_names = [field.name for field in bq_schema if field.name in new_restaurants_df.columns]
+        columns_str = ", ".join([f"`{col}`" for col in column_names])
+        source_columns_str = ", ".join([f"source.`{col}`" for col in column_names])
+        
+        merge_query = f"""
+        MERGE `{table_ref}` AS target
+        USING `{temp_table_ref}` AS source
+        ON target.fhrsid = source.fhrsid
+        WHEN NOT MATCHED THEN
+            INSERT ({columns_str})
+            VALUES ({source_columns_str})
+        """
+        
+        st.info("Executing MERGE to insert only new FHRSIDs...")
+        logging.info(f"MERGE query:\n{merge_query}")
+        
+        merge_job = client.query(merge_query)
+        merge_result = merge_job.result()
+        
+        # Get number of rows inserted
+        num_inserted = merge_job.num_dml_affected_rows
+        if num_inserted is not None:
+            st.success(f"Successfully merged data: {num_inserted} new records inserted into {table_ref}")
+            logging.info(f"MERGE completed: {num_inserted} rows inserted")
+        else:
+            st.success(f"MERGE completed successfully for {table_ref}")
+            logging.info("MERGE completed (row count not available)")
+        
+        # Step 3: Clean up temporary table
+        client.delete_table(temp_table_ref, not_found_ok=True)
+        logging.info(f"Temporary table {temp_table_ref} deleted")
+        
+        return True
+        
+    except Exception as e:
+        st.error(f"Error during MERGE operation: {e}")
+        logging.error(f"MERGE operation failed: {e}")
+        
+        # Try to clean up temp table even if merge failed
+        try:
+            client.delete_table(temp_table_ref, not_found_ok=True)
+        except:
+            pass
+            
+        return False
+
+
+def upsert_restaurants_to_bigquery(
+    restaurants_df: pd.DataFrame,
+    project_id: str,
+    dataset_id: str,
+    table_id: str,
+    bq_schema: List[bigquery.SchemaField],
+    update_columns: List[str] = None
+) -> bool:
+    """
+    Performs an UPSERT operation (UPDATE existing, INSERT new) on BigQuery table.
+    This is useful if you want to update certain fields for existing FHRSIDs
+    while inserting new ones.
+    
+    Args:
+        restaurants_df: DataFrame containing restaurant data with sanitized column names
+        project_id: The Google Cloud project ID
+        dataset_id: The BigQuery dataset ID
+        table_id: The BigQuery table ID
+        bq_schema: List of BigQuery schema fields
+        update_columns: List of column names to update for existing records.
+                       If None, only inserts new records (no updates).
+        
+    Returns:
+        True if upsert was successful, False otherwise
+    """
+    if restaurants_df.empty:
+        st.info("No restaurants to upsert into BigQuery.")
+        return True
+    
+    client = bigquery.Client(project=project_id)
+    table_ref = f"{project_id}.{dataset_id}.{table_id}"
+    temp_table_id = f"{table_id}_upsert_temp_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+    temp_table_ref = f"{project_id}.{dataset_id}.{temp_table_id}"
+    
+    try:
+        # Step 1: Create a temporary table with the data
+        st.info(f"Creating temporary table for upsert with {len(restaurants_df)} records...")
+        
+        job_config = bigquery.LoadJobConfig(
+            schema=bq_schema,
+            write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+            column_name_character_map="V2",
+        )
+        
+        job = client.load_table_from_dataframe(
+            restaurants_df, 
+            temp_table_ref, 
+            job_config=job_config
+        )
+        job.result()
+        
+        # Step 2: Build and execute MERGE statement
+        column_names = [field.name for field in bq_schema if field.name in restaurants_df.columns]
+        
+        # Build UPDATE clause if update_columns specified
+        if update_columns:
+            update_set_clause = ", ".join([
+                f"target.`{col}` = source.`{col}`" 
+                for col in update_columns 
+                if col in column_names and col != 'fhrsid'  # Don't update the key
+            ])
+            when_matched_clause = f"""
+            WHEN MATCHED THEN
+                UPDATE SET {update_set_clause}
+            """ if update_set_clause else ""
+        else:
+            when_matched_clause = ""
+        
+        # Build INSERT clause
+        insert_columns = ", ".join([f"`{col}`" for col in column_names])
+        insert_values = ", ".join([f"source.`{col}`" for col in column_names])
+        
+        merge_query = f"""
+        MERGE `{table_ref}` AS target
+        USING `{temp_table_ref}` AS source
+        ON target.fhrsid = source.fhrsid
+        {when_matched_clause}
+        WHEN NOT MATCHED THEN
+            INSERT ({insert_columns})
+            VALUES ({insert_values})
+        """
+        
+        st.info("Executing UPSERT operation...")
+        logging.info(f"UPSERT query:\n{merge_query}")
+        
+        merge_job = client.query(merge_query)
+        merge_result = merge_job.result()
+        
+        num_affected = merge_job.num_dml_affected_rows
+        if num_affected is not None:
+            st.success(f"Successfully upserted data: {num_affected} records affected in {table_ref}")
+            logging.info(f"UPSERT completed: {num_affected} rows affected")
+        else:
+            st.success(f"UPSERT completed successfully for {table_ref}")
+            logging.info("UPSERT completed (row count not available)")
+        
+        # Step 3: Clean up temporary table
+        client.delete_table(temp_table_ref, not_found_ok=True)
+        logging.info(f"Temporary table {temp_table_ref} deleted")
+        
+        return True
+        
+    except Exception as e:
+        st.error(f"Error during UPSERT operation: {e}")
+        logging.error(f"UPSERT operation failed: {e}")
+        
+        # Try to clean up temp table
+        try:
+            client.delete_table(temp_table_ref, not_found_ok=True)
+        except:
+            pass
+            
+        return False

--- a/enhanced_st_app_section.py
+++ b/enhanced_st_app_section.py
@@ -1,0 +1,141 @@
+"""
+Enhanced section for st_app.py that uses MERGE instead of APPEND
+to ensure duplicate prevention at the database level.
+
+This can replace the _append_new_data_to_bigquery function in st_app.py
+"""
+
+from typing import List, Dict, Any
+import streamlit as st
+import pandas as pd
+from google.cloud import bigquery
+from bq_utils import sanitize_column_name
+from bq_utils_merge import merge_new_restaurants_to_bigquery
+
+
+def _append_new_data_to_bigquery_with_merge(new_restaurants: List[Dict[str, Any]], project_id: str, dataset_id: str, table_id: str):
+    """
+    Enhanced version that uses MERGE to ensure no duplicate FHRSIDs are inserted.
+    This provides database-level guarantee against duplicates, even if the 
+    in-memory duplicate check somehow misses a record.
+    
+    Args:
+        new_restaurants: List of new restaurant dictionaries to add
+        project_id: The Google Cloud project ID
+        dataset_id: The BigQuery dataset ID
+        table_id: The BigQuery table ID
+    """
+    if not new_restaurants:
+        st.info("No new restaurants found to add to BigQuery.")
+        return
+    
+    st.info(f"Preparing {len(new_restaurants)} new records for BigQuery merge...")
+    df_new_restaurants = pd.json_normalize(new_restaurants)
+    
+    # Define comprehensive schema for merge operation
+    bq_schema_for_merge = [
+        bigquery.SchemaField(sanitize_column_name('FHRSID'), 'STRING'),
+        bigquery.SchemaField(sanitize_column_name('LocalAuthorityBusinessID'), 'STRING'),
+        bigquery.SchemaField(sanitize_column_name('BusinessName'), 'STRING'),
+        bigquery.SchemaField(sanitize_column_name('BusinessType'), 'STRING'),
+        bigquery.SchemaField(sanitize_column_name('BusinessTypeID'), 'INTEGER'),
+        bigquery.SchemaField(sanitize_column_name('AddressLine1'), 'STRING'),
+        bigquery.SchemaField(sanitize_column_name('AddressLine2'), 'STRING', mode='NULLABLE'),
+        bigquery.SchemaField(sanitize_column_name('AddressLine3'), 'STRING', mode='NULLABLE'),
+        bigquery.SchemaField(sanitize_column_name('AddressLine4'), 'STRING', mode='NULLABLE'),
+        bigquery.SchemaField(sanitize_column_name('PostCode'), 'STRING'),
+        bigquery.SchemaField(sanitize_column_name('RatingValue'), 'STRING'),
+        bigquery.SchemaField(sanitize_column_name('RatingKey'), 'STRING'),
+        bigquery.SchemaField(sanitize_column_name('LocalAuthorityCode'), 'STRING'),
+        bigquery.SchemaField(sanitize_column_name('LocalAuthorityName'), 'STRING'),
+        bigquery.SchemaField(sanitize_column_name('LocalAuthorityWebSite'), 'STRING'),
+        bigquery.SchemaField(sanitize_column_name('LocalAuthorityEmailAddress'), 'STRING'),
+        bigquery.SchemaField(sanitize_column_name('Scores.Hygiene'), 'INTEGER', mode='NULLABLE'),
+        bigquery.SchemaField(sanitize_column_name('Scores.Structural'), 'INTEGER', mode='NULLABLE'),
+        bigquery.SchemaField(sanitize_column_name('Scores.ConfidenceInManagement'), 'INTEGER', mode='NULLABLE'),
+        bigquery.SchemaField(sanitize_column_name('SchemeType'), 'STRING'),
+        bigquery.SchemaField(sanitize_column_name('Geocode.Longitude'), 'FLOAT'),
+        bigquery.SchemaField(sanitize_column_name('Geocode.Latitude'), 'FLOAT'),
+        bigquery.SchemaField(sanitize_column_name('NewRatingPending'), 'BOOLEAN'),
+        bigquery.SchemaField(sanitize_column_name('first_seen'), 'DATE'),
+        bigquery.SchemaField(sanitize_column_name('manual_review'), 'STRING'),
+        bigquery.SchemaField(sanitize_column_name('gemini_insights'), 'STRING', mode='NULLABLE')
+    ]
+    
+    # Sanitize DataFrame column names
+    sanitized_df_columns = {}
+    for orig_col in df_new_restaurants.columns:
+        sanitized = sanitize_column_name(orig_col)
+        sanitized_df_columns[orig_col] = sanitized
+    
+    df_new_restaurants.columns = df_new_restaurants.columns.map(sanitized_df_columns)
+    
+    # Convert data types as needed
+    
+    # Convert first_seen to date
+    s_first_seen = sanitize_column_name('first_seen')
+    if s_first_seen in df_new_restaurants.columns:
+        df_new_restaurants[s_first_seen] = pd.to_datetime(df_new_restaurants[s_first_seen], errors='coerce')
+    
+    # Convert score columns to integers
+    score_cols_original = ['Scores.Hygiene', 'Scores.Structural', 'Scores.ConfidenceInManagement']
+    for orig_col_name in score_cols_original:
+        s_col_name = sanitize_column_name(orig_col_name)
+        if s_col_name in df_new_restaurants.columns:
+            df_new_restaurants[s_col_name] = pd.to_numeric(df_new_restaurants[s_col_name], errors='coerce').astype('Int64')
+    
+    # Ensure FHRSID is string
+    s_fhrsid = sanitize_column_name('FHRSID')
+    if s_fhrsid in df_new_restaurants.columns:
+        df_new_restaurants[s_fhrsid] = df_new_restaurants[s_fhrsid].astype(str)
+    
+    # Convert BusinessTypeID to integer
+    s_business_type_id = sanitize_column_name('BusinessTypeID')
+    if s_business_type_id in df_new_restaurants.columns:
+        df_new_restaurants[s_business_type_id] = pd.to_numeric(df_new_restaurants[s_business_type_id], errors='coerce').astype('Int64')
+    
+    # Convert geocode columns to float
+    s_lon = sanitize_column_name('Geocode.Longitude')
+    if s_lon in df_new_restaurants.columns:
+        df_new_restaurants[s_lon] = pd.to_numeric(df_new_restaurants[s_lon], errors='coerce')
+    
+    s_lat = sanitize_column_name('Geocode.Latitude')
+    if s_lat in df_new_restaurants.columns:
+        df_new_restaurants[s_lat] = pd.to_numeric(df_new_restaurants[s_lat], errors='coerce')
+    
+    # Convert NewRatingPending to boolean
+    s_new_rating = sanitize_column_name('NewRatingPending')
+    if s_new_rating in df_new_restaurants.columns:
+        mapping = {'true': True, 'false': False, 'TRUE': True, 'FALSE': False}
+        df_new_restaurants[s_new_rating] = df_new_restaurants[s_new_rating].astype(str).str.lower().map(mapping)
+        df_new_restaurants[s_new_rating] = df_new_restaurants[s_new_rating].astype('boolean')
+    
+    # Select only columns that exist in both DataFrame and schema
+    cols_to_keep = [field.name for field in bq_schema_for_merge if field.name in df_new_restaurants.columns]
+    df_for_bq = df_new_restaurants[cols_to_keep]
+    
+    # Filter schema to match DataFrame columns
+    final_bq_schema = [field for field in bq_schema_for_merge if field.name in df_for_bq.columns]
+    
+    if df_for_bq.empty:
+        st.warning("After processing, the DataFrame for new restaurants is empty. Skipping BigQuery merge.")
+        return
+    
+    # Use MERGE instead of APPEND
+    success = merge_new_restaurants_to_bigquery(
+        new_restaurants_df=df_for_bq,
+        project_id=project_id,
+        dataset_id=dataset_id,
+        table_id=table_id,
+        bq_schema=final_bq_schema
+    )
+    
+    if success:
+        st.success(f"Successfully merged new records to BigQuery table {project_id}.{dataset_id}.{table_id}. Duplicates were automatically skipped.")
+    else:
+        st.error(f"Failed to merge new records to BigQuery table {project_id}.{dataset_id}.{table_id}.")
+
+
+# Usage in handle_fetch_data_action:
+# Replace the call to _append_new_data_to_bigquery with:
+# _append_new_data_to_bigquery_with_merge(new_restaurants, project_id_append, dataset_id_append, table_id_append)


### PR DESCRIPTION
Introduce optional BigQuery MERGE functionality for database-level duplicate prevention.

This PR provides an optional enhancement to ensure no duplicate FHRSIDs are inserted into BigQuery, even if application-level checks were to fail. It includes a new utility for MERGE operations and a guide explaining both the existing duplicate prevention and the new MERGE option.

---
<a href="https://cursor.com/background-agent?bcId=bc-3b5510a4-dd71-446d-a9b5-845f91e9d4f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3b5510a4-dd71-446d-a9b5-845f91e9d4f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

